### PR TITLE
Typo in info.xml: "<comment>" -> "<comments>"

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -21,7 +21,7 @@
   <civix>
     <namespace>CRM/Eventmembershipsignup</namespace>
   </civix>
-  <comment>
+  <comments>
     An administrator may tie an option in a price field to an event or membership type.  When a site visitor registers for an event and selects a price option, they will be registered for the additional event or have a new or renewed membership with that membership type.
-  </comment>
+  </comments>
 </extension>


### PR DESCRIPTION
As it is, the <comment> value doesn't display in the CiviCRM Extensions page.  This small change fixes that.