### PR TITLE
issues/20 get participant context if needed to create a membership

### DIFF
--- a/CRM/Eventmembershipsignup/Frontend.php
+++ b/CRM/Eventmembershipsignup/Frontend.php
@@ -181,6 +181,11 @@ HERESQL;
    * @param  object $objectRef            Object being processed (Participant or Membership Record)
    */
   public static function registerForMembershipAddons($price_field_value_id, $entityRefId, $objectRef) {
+    //sanity checks
+    if (empty($participant) && $objectRef->entity_table == 'civicrm_participant' && $objectRef->entity_id) {
+      //get some context for a membership add
+      $participant = civicrm_api3('Participant', 'getsingle', array('id' => $objectRef->entity_id));
+    }
     try {
       $newMemParams = array(
         'membership_type_id' => $entityRefId,


### PR DESCRIPTION
Issue described in #20 

To reproduce: Install the extension. Create a price set for use with an event (I used the Fall Fundraiser dinner event). Add a price option for the event and one with an additional signup for a membership (it can be the same field, separate fields, or even the same option). Set this price set to the event and do a live registration.

Before: You may notice a warning for undefined variable $participant. The event registration will go through, all charges will go through, a participant will be created. No membership will be created.

After: The membership is created as expected.