### PR TITLE
Issue 14: Only show future events

### DIFF
--- a/CRM/Eventmembershipsignup/Admin.php
+++ b/CRM/Eventmembershipsignup/Admin.php
@@ -135,6 +135,13 @@ HERESQL;
         'multiple' => TRUE,
         'placeholder' => '- ' . ts('Select Event', array('domain' => 'com.aghstrategies.eventmembershipsignup')) . ' -',
         'select' => array('minimumInputLength' => 0),
+        'api' => array(
+          'params' => array(
+            'start_date' => array('>=' => 'NOW'),
+            'id' => $dao->entity_ref_id,
+            'options' => array('or' => array(array('id', 'start_date')))
+          )
+        ),
       ));
       $selectors[] = $i;
     }
@@ -249,6 +256,13 @@ HERESQL;
       'multiple' => TRUE,
       'placeholder' => '- ' . ts('Select Event', array('domain' => 'com.aghstrategies.eventmembershipsignup')) . ' -',
       'select' => array('minimumInputLength' => 0),
+      'api' => array(
+        'params' => array(
+          'start_date' => array('>=' => 'NOW'),
+          'id' => $dao->entity_ref_id,
+          'options' => array('or' => array(array('id', 'start_date')))
+        )
+      ),
     ));
 
     $form->setDefaults($defaults);

--- a/info.xml
+++ b/info.xml
@@ -9,7 +9,7 @@
     <email>info@aghstrategies.com</email>
   </maintainer>
   <releaseDate>2017-12-12</releaseDate>
-  <version>2.5</version>
+  <version>2.5.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.18</ver>


### PR DESCRIPTION
Address #14 to only show future events in the dropdown, while keeping the currently-selected event available even if it's in the past.