### PR TITLE
SMARTY4 complaince

### DIFF
--- a/templates/pricefieldOthersignup.tpl
+++ b/templates/pricefieldOthersignup.tpl
@@ -2,7 +2,7 @@
 {* Licensed under the GNU Affero Public License 3.0 (see LICENSE.txt) *}
 
 {crmScope extensionKey='com.aghstrategies.eventmembershipsignup'}
-{crmScript ext=com.aghstrategies.eventmembershipsignup file=js/pricefieldOthersignup.js}
+{crmScript ext='com.aghstrategies.eventmembershipsignup' file='js/pricefieldOthersignup.js'}
 <table class="deleteme"><tr>
 {foreach from=$selectors item=i}
   <td id="othersignup-group-{$i}" class='othersignup-group'>

--- a/templates/priceoptionOthersignup.tpl
+++ b/templates/priceoptionOthersignup.tpl
@@ -2,7 +2,7 @@
 {* Licensed under the GNU Affero Public License 3.0 (see LICENSE.txt) *}
 
 {crmScope extensionKey='com.aghstrategies.eventmembershipsignup'}
-{crmScript ext=com.aghstrategies.eventmembershipsignup file=js/priceoptionOthersignup.js}
+{crmScript ext='com.aghstrategies.eventmembershipsignup' file='js/priceoptionOthersignup.js'}
 
 <table class="deleteme">
   <tbody id="other-sign-up">


### PR DESCRIPTION
After we upgraded a client to SMARTY4 we started getting errors while editing Pricesets. It was complaining because the `ext` and `file` values set in the templates were not quoted.

This pull request should quickly resolve those problems.